### PR TITLE
feat: make the processor configurable to customize termynal.js behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ markdown_extensions:
 [...]
 ```
 
+This config allows you to use another prompt:
+
+````markdown
+<!-- termynal -->
+
+```
+> pip install termynal
+---> 100%
+Installed
+```
+
+````
+
 ## Credits
 
 Thanks [ines](https://github.com/ines/termynal)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ comment, start with `#`
 ```
 ````
 
-`mkdocs` plugin
+### Mkdocs integration
+
+Declare the plugin:
 
 ```yaml
 ...
@@ -69,5 +71,19 @@ plugins:
   - termynal
 ...
 ```
+
+Optionally, pass options to the processor:
+
+```yaml
+[...]
+markdown_extensions:
+  - termynal:
+      prompt_literal_start:
+        - "$ "
+        - "&gt; "
+[...]
+```
+
+## Credits
 
 Thanks [ines](https://github.com/ines/termynal)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,3 +27,8 @@ markdown_extensions:
   - admonition
   - codehilite
   - pymdownx.superfences
+  - termynal:
+      prompt_literal_start:
+        - "$ "
+        - "&gt; "
+        - "&gt;&gt;&gt; "

--- a/termynal/markdown.py
+++ b/termynal/markdown.py
@@ -1,6 +1,7 @@
 import re
 from typing import Dict, List
 
+from markdown import core
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
@@ -16,9 +17,10 @@ class Termynal:
     def convert(self, code: str) -> List[str]:
         code_lines = []
         code_lines.append('<div class="termy" data-termynal>')
-        for line in self.code.split("\n"):
-            if line.startswith(self.prompt_literal_start):
-                code_lines.append(f'<span data-ty="input">{line[2:]}</span>')
+        for line in code.split("\n"):
+            if (match := re.match(rf"^({'|'.join(self.prompt_literal_start)})", line)):
+                used_prompt = match.group()
+                code_lines.append(f'<span data-ty="input" data-ty-prompt="{used_prompt}">{line.rsplit(used_prompt)[1]}</span>')
             elif line.startswith(self.custom_literal_start):
                 code_lines.append(
                     f'<span class="termynal-comment" data-ty>{line}</span>',

--- a/termynal/markdown.py
+++ b/termynal/markdown.py
@@ -36,6 +36,12 @@ class TermynalPreprocessor(Preprocessor):
     comment = "<!-- termynal -->"
     language_class = 'class="language-console"'
 
+    def __init__(self, config: dict, md: core.Markdown):
+        """Initialize."""
+        self.prompt_literal_start = config.get("prompt_literal_start", ("$ ", "> ",))
+
+        super(TermynalPreprocessor, self).__init__(md=md)
+
     def run(self, lines: List):
         content_by_placeholder = {}
         for i in range(self.md.htmlStash.html_counter):
@@ -92,10 +98,29 @@ class TermynalPreprocessor(Preprocessor):
 
 
 class TermynalExtension(Extension):
-    def extendMarkdown(self, md):  # noqa:N802
+    def __init__(self, *args, **kwargs):
+        """Initialize."""
+
+        self.config = {
+            "prompt_literal_start": [
+                [
+                    "$ ",
+                ],
+                "A list of prompt characters start to consider as console - Default: ['$ ',]"
+            ],
+
+        }
+
+        super(TermynalExtension, self).__init__(*args, **kwargs)
+
+    def extendMarkdown(self, md: core.Markdown):  # noqa:N802
+        """Register the extension."""
         md.registerExtension(self)
-        md.preprocessors.register(TermynalPreprocessor(md), "termynal", 20)
+        config = self.getConfigs()
+        md.preprocessors.register(TermynalPreprocessor(config, md), "termynal", 20)
 
 
-def makeExtension(**kwargs):  # noqa:N802  # pylint:disable=invalid-name
-    return TermynalExtension(**kwargs)
+def makeExtension(*args, **kwargs):  # noqa:N802  # pylint:disable=invalid-name
+    """Return extension."""
+
+    return TermynalExtension(*args, **kwargs)

--- a/termynal/markdown.py
+++ b/termynal/markdown.py
@@ -1,9 +1,11 @@
 import re
-from typing import Dict, List
+from typing import TYPE_CHECKING, Dict, List
 
-from markdown import core
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
+
+if TYPE_CHECKING:  # pragma:no cover
+    from markdown import core
 
 
 class Termynal:
@@ -42,7 +44,7 @@ class TermynalPreprocessor(Preprocessor):
     comment = "<!-- termynal -->"
     language_class = 'class="language-console"'
 
-    def __init__(self, config: dict, md: core.Markdown):
+    def __init__(self, config: dict, md: "core.Markdown"):
         """Initialize."""
         self.prompt_literal_start = config.get("prompt_literal_start", ("$ ",))
 
@@ -119,7 +121,7 @@ class TermynalExtension(Extension):
 
         super(TermynalExtension, self).__init__(*args, **kwargs)
 
-    def extendMarkdown(self, md: core.Markdown):  # noqa:N802
+    def extendMarkdown(self, md: "core.Markdown"):  # noqa:N802
         """Register the extension."""
         md.registerExtension(self)
         config = self.getConfigs()

--- a/termynal/markdown.py
+++ b/termynal/markdown.py
@@ -7,13 +7,13 @@ from markdown.preprocessors import Preprocessor
 
 class Termynal:
     progress_literal_start = "---&gt; 100%"
-    prompt_literal_start = "$ "
     custom_literal_start = "# "
 
-    def __init__(self, code: str):
-        self.code = code
+    def __init__(self, prompt_literal_start: tuple = ("$ ",)):
+        """Initialize."""
+        self.prompt_literal_start = tuple(prompt_literal_start)
 
-    def convert(self) -> List[str]:
+    def convert(self, code: str) -> List[str]:
         code_lines = []
         code_lines.append('<div class="termy" data-termynal>')
         for line in self.code.split("\n"):
@@ -64,6 +64,7 @@ class TermynalPreprocessor(Preprocessor):
         lines: List,
         content_by_placeholder: Dict,
     ):  # pylint:disable=too-many-nested-blocks
+        termynal_obj = Termynal(prompt_literal_start=self.prompt_literal_start)
         lines_by_placeholder = {}
         is_termynal_code = False
         for line in lines:
@@ -90,7 +91,7 @@ class TermynalPreprocessor(Preprocessor):
                 is_termynal_code = False
                 self.md.htmlStash.rawHtmlBlocks[i] = ""
                 content = matches.group(2)
-                code_lines = Termynal(content).convert()
+                code_lines = termynal_obj.convert(code=content)
                 if code_lines:
                     lines_by_placeholder[line] = code_lines
 

--- a/termynal/markdown.py
+++ b/termynal/markdown.py
@@ -38,7 +38,7 @@ class TermynalPreprocessor(Preprocessor):
 
     def __init__(self, config: dict, md: core.Markdown):
         """Initialize."""
-        self.prompt_literal_start = config.get("prompt_literal_start", ("$ ", "> ",))
+        self.prompt_literal_start = config.get("prompt_literal_start", ("$ ",))
 
         super(TermynalPreprocessor, self).__init__(md=md)
 

--- a/tests/test_markdown_extension.py
+++ b/tests/test_markdown_extension.py
@@ -1,5 +1,7 @@
 # pylint:disable=redefined-outer-name
 # pylint:disable=invalid-name
+from typing import Dict
+
 import pytest
 from markdown import markdown
 
@@ -20,7 +22,7 @@ expected_html = """<h1>Header</h1>
 ---&gt; 100%
 </code></pre>"""
 
-config = {}
+config: Dict[str, str] = {}
 
 md2 = """
 # Header

--- a/tests/test_markdown_extension.py
+++ b/tests/test_markdown_extension.py
@@ -20,6 +20,7 @@ expected_html = """<h1>Header</h1>
 ---&gt; 100%
 </code></pre>"""
 
+config = {}
 
 md2 = """
 # Header
@@ -38,7 +39,7 @@ expected_html2 = """<h1>Header</h1>
 
 <p>
 <div class="termy" data-termynal>
-<span data-ty="input">pip install termynal</span>
+<span data-ty="input" data-ty-prompt="$">pip install termynal</span>
 <span data-ty="progress"></span>
 <span data-ty></span>
 </div></p>"""
@@ -57,22 +58,80 @@ $ pip install termynal
 expected_html3 = """<h1>Header</h1>
 <p>
 <div class="termy" data-termynal>
-<span data-ty="input">pip install termynal</span>
+<span data-ty="input" data-ty-prompt="$">pip install termynal</span>
 <span data-ty="progress"></span>
 <span data-ty></span>
 </div></p>"""
 
+# -- MD 4
+md4 = """
+# Header
+
+<!-- termynal -->
+
+```
+$ pip install termynal
+---> 100%
+```
+"""
+
+expected_html4 = """<h1>Header</h1>
+<!-- termynal -->
+
+<p>
+<div class="termy" data-termynal>
+<span data-ty>$ pip install termynal</span>
+<span data-ty="progress"></span>
+<span data-ty></span>
+</div></p>"""
+
+config4 = {"prompt_literal_start": ["&gt; "]}
+
+# -- MD 5 --
+md5 = """
+# Header
+
+<!-- termynal -->
+
+```
+> pip install termynal
+---> 100%
+```
+"""
+
+expected_html5 = """<h1>Header</h1>
+<!-- termynal -->
+
+<p>
+<div class="termy" data-termynal>
+<span data-ty="input" data-ty-prompt="&gt;">pip install termynal</span>
+<span data-ty="progress"></span>
+<span data-ty></span>
+</div></p>"""
+
+config5 = {"prompt_literal_start": ["&gt; "]}
+
 
 @pytest.mark.parametrize(
-    ("md", "expected_html"),
-    [(md, expected_html), (md2, expected_html2), (md3, expected_html3)],
+    ("md", "expected_html", "config"),
+    [
+        (md, expected_html, config),
+        (md2, expected_html2, config),
+        (md3, expected_html3, config),
+        (md4, expected_html4, config4),
+        (md5, expected_html5, config5),
+    ],
 )
-def test_converting(md, expected_html):
+def test_converting(
+    md: str,
+    expected_html: str,
+    config: dict,
+):
     html = markdown(
         md,
         extensions=[
             "fenced_code",
-            TermynalExtension(),
+            TermynalExtension(**config),
         ],
     )
     assert html == expected_html


### PR DESCRIPTION
Hello @daxartio, in this PR, I propose to expose some options related to termynal.js to the markdown processor.

Given this markdown:

````markdown
# Header

<!-- termynal -->

```
> pip install --upgrade termynal
---> 100%
```
````

You can then use this:

```python
def convert(md: str, config: dict = {}):
    return markdown(
        md,
        extensions=[
            "fenced_code",
            TermynalExtension(**{"prompt_literal_start": ["&gt; "]}),
        ],
    )
```

And so, through the Mkdocs plugin:

```yaml
[...]
markdown_extensions:
  - admonition
  - codehilite
  - pymdownx.superfences
  - termynal:
      prompt_literal_start:
        - "$ "
        - "&gt; "
[...]
```

For now, the only supported option is `prompt_literal_start`, corresponding to the [`data-ty-prompt`](https://github.com/ines/termynal#data-ty-prompt-prompt-style) of _termynal.js_.

Sorry for the multiple commits, I've been interrupted so it's quite messy. If you want, I can squash.

----

## About the tooling

As said in my previous PR, I don't use poetry and I'm not willing to. But to play fair, I tried to comply with the required setup to contribute to your project and I've installed poetry (running Ubuntu 22.04).

Still, I'm facing this issue:

```sh
termynal on  feature/make-it-configurable is 📦 v0.3.1 via 🐍 v3.8.10 
❯ make all
poetry run ruff --fix termynal tests

  RuntimeError

  The Poetry configuration is invalid:
    - Additional properties are not allowed ('group' was unexpected)
  

  at ~/.poetry/lib/poetry/_vendor/py3.10/poetry/core/factory.py:43 in create_poetry
       39│             message = ""
       40│             for error in check_result["errors"]:
       41│                 message += "  - {}\n".format(error)
       42│ 
    →  43│             raise RuntimeError("The Poetry configuration is invalid:\n" + message)
       44│ 
       45│         # Load package
       46│         name = local_config["name"]
       47│         version = local_config["version"]
make: *** [Makefile:55 : format] Erreur 1
```

Then I'm using `ruff` too, but installing it with pip and running it, I do not have the same error than in the CI...
