### PR TITLE
fix: display Windows buttons in top right

### DIFF
--- a/termynal/assets/termynal.css
+++ b/termynal/assets/termynal.css
@@ -37,6 +37,7 @@
    content: '';
    position: absolute;
    top: 15px;
+   left: unset;
    right: 15px;
    display: inline-block;
    width: 15px;


### PR DESCRIPTION
The window buttons when set to Windows would be displayed incorrectly in the top left. Setting `left` to `unset` makes it so that the `right` property actually has effect.

Old:
<img width="852" height="251" alt="image" src="https://github.com/user-attachments/assets/951334c0-47f0-42c7-862f-ffbf5807de3f" />

New:
<img width="846" height="241" alt="image" src="https://github.com/user-attachments/assets/fb65b4a7-54a3-412a-b5c4-6d011ff1f9f5" />
